### PR TITLE
Add reboot and ap_mode API support

### DIFF
--- a/opengarage/__init__.py
+++ b/opengarage/__init__.py
@@ -45,6 +45,20 @@ class OpenGarage:
         if result is None:
             return None
         return result.get("result")
+    
+    async def reboot(self):
+        """Reboot device."""
+        result = await self._execute(f"cc?dkey={self._devkey}&reboot=1")
+        if result is None:
+            return None
+        return result.get("result")
+    
+    async def ap_mode(self):
+        """Reset device in AP mode (to reconfigure WiFi settings)."""
+        result = await self._execute(f"cc?dkey={self._devkey}&apmode=1")
+        if result is None:
+            return None
+        return result.get("result")
 
     async def _execute(self, command, retry=2):
         """Execute command."""


### PR DESCRIPTION
This adds Python API support for these actions as per the API docs at https://raw.githubusercontent.com/OpenGarage/OpenGarage-Firmware/master/docs/OGAPI1.1.0.pdf. My use case is for these actions to eventually end up as switches within Home Assistant so it's possible to easily restart the OG and trigger a reconfigure its wifi from HA.