### PR TITLE
Expose API methods for explicit open and close operations

### DIFF
--- a/opengarage/__init__.py
+++ b/opengarage/__init__.py
@@ -57,6 +57,20 @@ class OpenGarage:
             return None
         return result.get("result")
 
+    async def push_close_button(self):
+        """Push close button.  No-op if already closed."""
+        result = await self._execute(f"cc?dkey={self._devkey}&close=1")
+        if result is None:
+            return None
+        return result.get("result")
+
+    async def push_open_button(self):
+        """Push open button.  No-op if already open."""
+        result = await self._execute(f"cc?dkey={self._devkey}&open=1")
+        if result is None:
+            return None
+        return result.get("result")
+
     async def reboot(self):
         """Reboot device."""
         result = await self._execute(f"cc?dkey={self._devkey}&reboot=1")


### PR DESCRIPTION
This is useful for creating idempotent operations. For my particular use case, Home Assistant's local polling of the OpenGarage device leads to situations where HA gets out of sync with the physical state of the garage door, and automation rules can wrongly trigger the door to open or close.

Allowing HA to assert an *intent* via explicit open or close instead of a simple "toggle" means fewer scratches on my car's roof from the garage door closing on it.